### PR TITLE
Fix Responsive Menu CSS Bug

### DIFF
--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,5 +1,5 @@
-@handsetQuery: ~"screen and (max-width:599px)";
-@tabletQuery: ~"screen and (min-width:600px) and (max-width:1024px)";
+@handsetQuery: ~"screen and (max-width:668px)";
+@tabletQuery: ~"screen and (min-width:669px) and (max-width:1024px)";
 @desktopQuery: ~"screen and (min-width:1025px)";
 @printQuery: ~"print";
 


### PR DESCRIPTION
This fixes a responsive css bug where the top nav doesn't collapse into the hamburger nav properly when a device's width is between 600 and 669 pixels.
